### PR TITLE
Cleanup test project properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
+    <EngRootPath>$(RepoRootPath)eng/</EngRootPath>
     <SourceRootPath>$(RepoRootPath)src</SourceRootPath>
     <CentralBuildOutputPath>$(RepoRootPath)</CentralBuildOutputPath>
   </PropertyGroup>

--- a/eng/noop.targets
+++ b/eng/noop.targets
@@ -1,0 +1,7 @@
+<Project>
+
+  <Target Name="Build">
+      <Message Importance="High" Text="$(MSBuildProjectName) has been skipped." />
+  </Target>
+
+</Project>

--- a/src/MemberOrder/MemberOrder.Vsix/MemberOrder.Vsix.csproj
+++ b/src/MemberOrder/MemberOrder.Vsix/MemberOrder.Vsix.csproj
@@ -45,4 +45,6 @@
     <ProjectReference Update="@(ProjectReference)" Name="%(Filename)" />
   </ItemGroup>
 
+  <Import Project="$(EngRootPath)noop.targets" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
+
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,7 +1,19 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <!-- Don't publish test projects by default. -->
+    <IsPublishable>false</IsPublishable>
+
+    <!-- Prevent test projects from being packaged by default. -->
+    <IsPackable>false</IsPackable>
+
+    <!-- Mark projects as test by default. -->
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Exclude test projects from code coverate reports. -->
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)/../Directory.Build.props" />
 </Project>

--- a/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrder.CodeFixes.Tests.csproj
+++ b/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrder.CodeFixes.Tests.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrder.Tests.csproj
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrder.Tests.csproj
@@ -2,12 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change cleans up the default test project properties, excludes them from code coverage reporting, and removes the VSIX project from .NET CLI builds.