### PR TITLE
Exclude generated code from code coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute="GeneratedCodeAttribute,CompilerGeneratedAttribute"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --% /p:ExcludeByAttribute=\"GeneratedCodeAttribute,CompilerGeneratedAttribute\"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true
         shell: pwsh
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --% /p:ExcludeByAttribute="GeneratedCodeAttribute,CompilerGeneratedAttribute"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --% /p:ExcludeByAttribute=\"GeneratedCodeAttribute,CompilerGeneratedAttribute\"
         shell: pwsh
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,8 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute="GeneratedCodeAttribute,CompilerGeneratedAttribute"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --% /p:ExcludeByAttribute="GeneratedCodeAttribute,CompilerGeneratedAttribute"
+        shell: pwsh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --% /p:ExcludeByAttribute=\"GeneratedCodeAttribute,CompilerGeneratedAttribute\"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true
         shell: pwsh
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute="GeneratedCodeAttribute,CompilerGeneratedAttribute"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -37,7 +37,8 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute="GeneratedCodeAttribute,CompilerGeneratedAttribute"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --% /p:ExcludeByAttribute="GeneratedCodeAttribute,CompilerGeneratedAttribute"
+        shell: pwsh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --% /p:ExcludeByAttribute="GeneratedCodeAttribute,CompilerGeneratedAttribute"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --% /p:ExcludeByAttribute=\"GeneratedCodeAttribute,CompilerGeneratedAttribute\"
         shell: pwsh
 
       - name: Upload coverage to Codecov

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,6 +8,10 @@
 
     <!-- Mark projects as test by default. -->
     <IsTestProject>true</IsTestProject>
+
+    <!-- Configure code coverage settings for coverlet. -->
+    <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -4,6 +4,7 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector"                                Version="6.0.0" />
+    <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.7.2" />
     <!-- <PackageVersion Include="xunit"                                             Version="2.5.1" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.1" /> -->

--- a/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrder.CodeFixes.Tests.csproj
+++ b/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrder.CodeFixes.Tests.csproj
@@ -5,7 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrder.Tests.csproj
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrder.Tests.csproj
@@ -5,7 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />


### PR DESCRIPTION
Added the `coverlet.msbuild` package to enable new parameters to exclude code attributed as generated.