### PR TITLE
Add support for sorting more keywords and nested types

### DIFF
--- a/src/MemberOrder/MemberOrder.CodeFixes/MemberOrderCodeFixProvider.cs
+++ b/src/MemberOrder/MemberOrder.CodeFixes/MemberOrderCodeFixProvider.cs
@@ -96,8 +96,8 @@ public class MemberOrderCodeFixProvider : CodeFixProvider
         if (firstMember != firstSortedMember)
         {
             sortedMembers[0] = firstSortedMember
-                .WithLeadingTrivia(firstMember.GetLeadingTrivia())
-                .WithTrailingTrivia(firstMember.GetTrailingTrivia());
+                .WithLeadingWhitespaceFrom(firstMember)
+                .WithTrailingTriviaFrom(firstMember);
         }
 
         int lastIndex = sortedMembers.Count - 1;
@@ -107,8 +107,8 @@ public class MemberOrderCodeFixProvider : CodeFixProvider
         if (lastMember != lastSortedMember)
         {
             sortedMembers[lastIndex] = lastSortedMember
-                .WithTrailingTrivia(lastMember.GetTrailingTrivia())
-                .WithLeadingTrivia(lastMember.GetLeadingTrivia());
+                .WithLeadingWhitespaceFrom(lastMember)
+                .WithTrailingTriviaFrom(lastMember);
         }
     }
 }

--- a/src/MemberOrder/MemberOrder.CodeFixes/SyntaxExtensions.cs
+++ b/src/MemberOrder/MemberOrder.CodeFixes/SyntaxExtensions.cs
@@ -1,0 +1,50 @@
+﻿namespace Treasure.Analyzers.MemberOrder.CodeFixes;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+internal static class SyntaxExtensions
+{
+    public static IEnumerable<SyntaxTrivia> GetLeadingWhitespace(this SyntaxTriviaList triviaList)
+    {
+        foreach (SyntaxTrivia trivia in triviaList)
+        {
+            if (trivia.Kind() is SyntaxKind.WhitespaceTrivia or SyntaxKind.EndOfLineTrivia)
+            {
+                yield return trivia;
+            }
+            else
+            {
+                yield break;
+            }
+        }
+    }
+
+    public static MemberDeclarationSyntax WithLeadingWhitespaceFrom(this MemberDeclarationSyntax targetMember, MemberDeclarationSyntax whitespaceSourceMember)
+    {
+        IEnumerable<SyntaxTrivia> newLeadingWhitespace = whitespaceSourceMember.GetLeadingTrivia().GetLeadingWhitespace().ToArray();
+        IEnumerable<SyntaxTrivia> leadingNonWhitespace = targetMember.GetLeadingTrivia().WithoutLeadingWhitespace().ToArray();
+        return targetMember.WithLeadingTrivia(newLeadingWhitespace.Concat(leadingNonWhitespace));
+    }
+
+    public static IEnumerable<SyntaxTrivia> WithoutLeadingWhitespace(this SyntaxTriviaList triviaList)
+    {
+        bool takeRest = false;
+        foreach (SyntaxTrivia trivia in triviaList)
+        {
+            if (!takeRest && (trivia.Kind() is SyntaxKind.WhitespaceTrivia or SyntaxKind.EndOfLineTrivia))
+            {
+                continue;
+            }
+            else
+            {
+                takeRest = true;
+                yield return trivia;
+            }
+        }
+    }
+
+    public static MemberDeclarationSyntax WithTrailingTriviaFrom(this MemberDeclarationSyntax targetMember, MemberDeclarationSyntax sourceMember)
+        => targetMember.WithTrailingTrivia(sourceMember.GetTrailingTrivia());
+}

--- a/src/MemberOrder/MemberOrder/MemberOrderAnalyzer.cs
+++ b/src/MemberOrder/MemberOrder/MemberOrderAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿namespace Treasure.Analyzers.MemberOrder;
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -102,6 +103,7 @@ public class MemberOrderAnalyzer : DiagnosticAnalyzer
     /// </summary>
     /// <param name="member">The member.</param>
     /// <returns><see cref="int"/>.</returns>
+    [SuppressMessage("Style", "IDE0072:Add missing cases", Justification = "Selective handling with a default case.")]
     public static int GetMemberCategoryOrder(MemberDeclarationSyntax member)
     {
         if (member is null)
@@ -109,17 +111,23 @@ public class MemberOrderAnalyzer : DiagnosticAnalyzer
             throw new ArgumentNullException(nameof(member));
         }
 
-        return member switch
+        return member.Kind() switch
         {
-            FieldDeclarationSyntax => 0,
-            PropertyDeclarationSyntax => 1,
-            DelegateDeclarationSyntax => 2,
-            EventFieldDeclarationSyntax => 3,
-            EventDeclarationSyntax => 3,
-            IndexerDeclarationSyntax => 4,
-            ConstructorDeclarationSyntax => 5,
-            DestructorDeclarationSyntax => 6,
-            MethodDeclarationSyntax => 7,
+            SyntaxKind.FieldDeclaration => 0,
+            SyntaxKind.PropertyDeclaration => 1,
+            SyntaxKind.DelegateDeclaration => 2,
+            SyntaxKind.EventFieldDeclaration => 3,
+            SyntaxKind.EventDeclaration => 3,
+            SyntaxKind.IndexerDeclaration => 4,
+            SyntaxKind.ConstructorDeclaration => 5,
+            SyntaxKind.DestructorDeclaration => 6,
+            SyntaxKind.MethodDeclaration => 7,
+            SyntaxKind.EnumDeclaration => 8,
+            SyntaxKind.InterfaceDeclaration => 9,
+            SyntaxKind.StructDeclaration => 10,
+            SyntaxKind.RecordStructDeclaration => 11,
+            SyntaxKind.RecordDeclaration => 12,
+            SyntaxKind.ClassDeclaration => 13,
             _ => 99,
         };
     }
@@ -138,15 +146,16 @@ public class MemberOrderAnalyzer : DiagnosticAnalyzer
 
         return member switch
         {
-            FieldDeclarationSyntax field => field.Declaration.Variables.First().Identifier.Text,
+            // Field and Event Field
+            BaseFieldDeclarationSyntax field => field.Declaration.Variables.First().Identifier.Text,
             PropertyDeclarationSyntax property => property.Identifier.Text,
             DelegateDeclarationSyntax @delegate => @delegate.Identifier.Text,
             EventDeclarationSyntax @event => @event.Identifier.Text,
-            EventFieldDeclarationSyntax eventField => eventField.Declaration.Variables.First().Identifier.Text,
             IndexerDeclarationSyntax => string.Empty,
             ConstructorDeclarationSyntax constructor => constructor.Identifier.Text,
             DestructorDeclarationSyntax destructor => destructor.Identifier.Text,
             MethodDeclarationSyntax method => method.Identifier.Text,
+            BaseTypeDeclarationSyntax type => type.Identifier.Text,
             _ => throw new InvalidOperationException($"Unable to get member name: '{member}'"),
         };
     }

--- a/src/MemberOrder/MemberOrder/MemberOrderAnalyzer.cs
+++ b/src/MemberOrder/MemberOrder/MemberOrderAnalyzer.cs
@@ -147,7 +147,7 @@ public class MemberOrderAnalyzer : DiagnosticAnalyzer
             ConstructorDeclarationSyntax constructor => constructor.Identifier.Text,
             DestructorDeclarationSyntax destructor => destructor.Identifier.Text,
             MethodDeclarationSyntax method => method.Identifier.Text,
-            _ => throw new InvalidOperationException("Unable to get member name."),
+            _ => throw new InvalidOperationException($"Unable to get member name: '{member}'"),
         };
     }
 

--- a/src/MemberOrder/MemberOrder/MemberOrderAnalyzer.cs
+++ b/src/MemberOrder/MemberOrder/MemberOrderAnalyzer.cs
@@ -168,9 +168,19 @@ public class MemberOrderAnalyzer : DiagnosticAnalyzer
             return 0;
         }
 
-        if (member.Modifiers.Any(SyntaxKind.StaticKeyword))
+        if (member.Modifiers.Any(SyntaxKind.StaticKeyword) && member.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
         {
             return 1;
+        }
+
+        if (member.Modifiers.Any(SyntaxKind.StaticKeyword))
+        {
+            return 2;
+        }
+
+        if (member.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
+        {
+            return 3;
         }
 
         return 99;

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -6,9 +6,6 @@
     <PackageVersion Include="coverlet.collector"                                Version="6.0.0" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.7.2" />
-    <!-- <PackageVersion Include="xunit"                                             Version="2.5.1" />
-    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.1" /> -->
-
     <PackageVersion Include="MSTest.TestAdapter"                                Version="3.1.1" />
     <PackageVersion Include="MSTest.TestFramework"                              Version="3.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis"                            Version="4.7.0" />

--- a/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrderCodeFixProviderTests.cs
+++ b/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrderCodeFixProviderTests.cs
@@ -3,13 +3,72 @@
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using VerifyCSCodeFix = Test.Verifiers.CSharpCodeFixVerifier<
+using VerifyCS = Test.Verifiers.CSharpCodeFixVerifier<
     MemberOrderAnalyzer,
     MemberOrderCodeFixProvider>;
 
 [TestClass]
 public class MemberOrderCodeFixProviderTests
 {
+    [TestMethod]
+    public async Task CodeFix_Class_SubTypesOutOfOrder_Reordered()
+    {
+        string test = @"
+        public class MyClass
+        {
+            // Classes
+            public class MySubClass { }
+
+            // Records
+            public record MySubRecord { }
+
+            // Record structs
+            public record struct MySubRecordStruct { }
+
+            // Structs
+            public struct MySubStruct { }
+
+            // Interfaces
+            public interface IMySubInterface { }
+
+            // Enums
+            public enum MySubEnum { EnumValue, }
+
+            // Methods
+            public void MyPublicMethod() { }
+        }";
+
+        string fixtest = @"
+        public class MyClass
+        {
+            // Methods
+            public void MyPublicMethod() { }
+
+            // Enums
+            public enum MySubEnum { EnumValue, }
+
+            // Interfaces
+            public interface IMySubInterface { }
+
+            // Structs
+            public struct MySubStruct { }
+
+            // Record structs
+            public record struct MySubRecordStruct { }
+
+            // Records
+            public record MySubRecord { }
+
+            // Classes
+            public class MySubClass { }
+        }";
+
+        DiagnosticResult expected = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+            .WithLocation("", 2, 9)
+            .WithArguments("MyClass");
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
+    }
+
     [TestMethod]
     public async Task CodeFix_FieldsOutOfAccesibilityOrder_Reordered()
     {
@@ -27,10 +86,10 @@ public class MemberOrderCodeFixProviderTests
             private int myPrivateField;
         }";
 
-        DiagnosticResult expected = VerifyCSCodeFix.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+        DiagnosticResult expected = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
             .WithLocation("", 2, 9)
             .WithArguments("MyClass");
-        await VerifyCSCodeFix.VerifyCodeFixAsync(test, expected, fixtest);
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
     }
 
     [TestMethod]
@@ -50,10 +109,10 @@ public class MemberOrderCodeFixProviderTests
             public int myPublicFieldB;
         }";
 
-        DiagnosticResult expected = VerifyCSCodeFix.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+        DiagnosticResult expected = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
             .WithLocation("", 2, 9)
             .WithArguments("MyClass");
-        await VerifyCSCodeFix.VerifyCodeFixAsync(test, expected, fixtest);
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
     }
 
     [TestMethod]
@@ -79,10 +138,10 @@ public class MemberOrderCodeFixProviderTests
             public int myPublicField;
         }";
 
-        DiagnosticResult expected = VerifyCSCodeFix.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+        DiagnosticResult expected = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
             .WithLocation("", 2, 9)
             .WithArguments("MyClass");
-        await VerifyCSCodeFix.VerifyCodeFixAsync(test, expected, fixtest);
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
     }
 
     [TestMethod]
@@ -116,10 +175,10 @@ public class MemberOrderCodeFixProviderTests
             private void MyPrivateMethodB() { }
         }";
 
-        DiagnosticResult expected = VerifyCSCodeFix.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+        DiagnosticResult expected = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
             .WithLocation("", 2, 9)
             .WithArguments("MyClass");
-        await VerifyCSCodeFix.VerifyCodeFixAsync(test, expected, fixtest);
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
     }
 
     [TestMethod]
@@ -169,9 +228,9 @@ public class MemberOrderCodeFixProviderTests
             private void MyPrivateMethodB() { }
         }";
 
-        DiagnosticResult expected = VerifyCSCodeFix.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+        DiagnosticResult expected = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
             .WithLocation("", 2, 9)
             .WithArguments("MyClass");
-        await VerifyCSCodeFix.VerifyCodeFixAsync(test, expected, fixtest);
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
     }
 }

--- a/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrderCodeFixProviderTests.cs
+++ b/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrderCodeFixProviderTests.cs
@@ -63,7 +63,9 @@ public class MemberOrderCodeFixProviderTests
         class MyClass
         {
             public int myPublicField;
+            public readonly int myPublicReadonlyField = 1;
             public static int myPublicStaticField;
+            public static readonly int myPublicStaticReadonlyField;
             public const int myPublicConstantField = 0;
         }";
 
@@ -71,7 +73,9 @@ public class MemberOrderCodeFixProviderTests
         class MyClass
         {
             public const int myPublicConstantField = 0;
+            public static readonly int myPublicStaticReadonlyField;
             public static int myPublicStaticField;
+            public readonly int myPublicReadonlyField = 1;
             public int myPublicField;
         }";
 

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests.cs
@@ -171,40 +171,6 @@ public class MemberOrderUnitTest
     }
 
     [TestMethod]
-    public async Task Analyzer_Class_KeywordsInOrder_NoDiagnostics()
-    {
-        string test = @"
-        public class MyClass
-        {
-            // Fields
-            public const int myPublicConstantField = 0;
-            public static readonly int myPublicStaticReadonlyField;
-            public static int myPublicStaticField;
-            public readonly int myPublicReadonlyField = 1;
-            public int myPublicField;
-
-            // Properties
-            public static int MyPublicStaticProperty { get; set; }
-            public int MyPublicProperty { get; set; }
-
-            // Delegates
-            public delegate void MyPublicDelegate();
-
-            // Events and event fields
-            public static event MyPublicDelegate MyPublicStaticEvent { add { } remove { } }
-            public static event MyPublicDelegate MyPublicStaticEventField;
-            public event MyPublicDelegate MyPublicEvent { add { } remove { } }
-            public event MyPublicDelegate MyPublicEventField;
-
-            // Methods
-            public static void MyPublicStaticMethod() { }
-            public void MyPublicMethod() { }
-        }";
-
-        await VerifyCS.VerifyAnalyzerAsync(test);
-    }
-
-    [TestMethod]
     public async Task Analyzer_Class_ConstructorBeforeIndexer_SingleDiagnostic()
     {
         string test = @"
@@ -347,6 +313,40 @@ public class MemberOrderUnitTest
     }
 
     [TestMethod]
+    public async Task Analyzer_Class_KeywordsInOrder_NoDiagnostics()
+    {
+        string test = @"
+        public class MyClass
+        {
+            // Fields
+            public const int myPublicConstantField = 0;
+            public static readonly int myPublicStaticReadonlyField;
+            public static int myPublicStaticField;
+            public readonly int myPublicReadonlyField = 1;
+            public int myPublicField;
+
+            // Properties
+            public static int MyPublicStaticProperty { get; set; }
+            public int MyPublicProperty { get; set; }
+
+            // Delegates
+            public delegate void MyPublicDelegate();
+
+            // Events and event fields
+            public static event MyPublicDelegate MyPublicStaticEvent { add { } remove { } }
+            public static event MyPublicDelegate MyPublicStaticEventField;
+            public event MyPublicDelegate MyPublicEvent { add { } remove { } }
+            public event MyPublicDelegate MyPublicEventField;
+
+            // Methods
+            public static void MyPublicStaticMethod() { }
+            public void MyPublicMethod() { }
+        }";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [TestMethod]
     public async Task Analyzer_Class_MethodBeforeDeconstructor_SingleDiagnostic()
     {
         string test = @"
@@ -384,6 +384,37 @@ public class MemberOrderUnitTest
         };
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [TestMethod]
+    public async Task Analyzer_Class_SubTypes_NoDiagnostics()
+    {
+        string test = @"
+        public class MyClass
+        {
+            // Methods
+            public void MyPublicMethod() { }
+
+            // Enums
+            public enum MySubEnum { EnumValue, }
+
+            // Interfaces
+            public interface IMySubInterface { }
+
+            // Structs
+            public struct MySubStruct { }
+
+            // Record structs
+            public record struct MySubRecordStruct { }
+
+            // Records
+            public record MySubRecord { }
+
+            // Classes
+            public class MySubClass { }
+        }";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [TestMethod]

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests.cs
@@ -2,6 +2,8 @@
 
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -438,10 +440,33 @@ public class MemberOrderUnitTest
         Assert.ThrowsException<ArgumentNullException>(() => MemberOrderAnalyzer.GetMemberCategoryOrder(null!));
 
     [TestMethod]
+    public void GetMemberCategoryOrder_UnexpectedMember_Returns99()
+    {
+        // Arrange
+        MemberDeclarationSyntax unexpectedMemberSyntax = SyntaxFactory.NamespaceDeclaration(SyntaxFactory.IdentifierName("MyNamespace"));
+
+        // Act
+        int result = MemberOrderAnalyzer.GetMemberCategoryOrder(unexpectedMemberSyntax);
+
+        // Assert
+        Assert.AreEqual(99, result);
+    }
+
+    [TestMethod]
     public void GetMemberName_NullMember_ThrowsArgumentNullException() =>
 
         // Act and assert
         Assert.ThrowsException<ArgumentNullException>(() => MemberOrderAnalyzer.GetMemberName(null!));
+
+    [TestMethod]
+    public void GetMemberName_UnexpectedMember_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        MemberDeclarationSyntax unexpectedMemberSyntax = SyntaxFactory.NamespaceDeclaration(SyntaxFactory.IdentifierName("MyNamespace"));
+
+        // Act and assert
+        Assert.ThrowsException<InvalidOperationException>(() => MemberOrderAnalyzer.GetMemberName(unexpectedMemberSyntax));
+    }
 
     [TestMethod]
     public void GetSpecialKeywordOrder_NullMember_ThrowsArgumentNullException() =>

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests.cs
@@ -171,6 +171,40 @@ public class MemberOrderUnitTest
     }
 
     [TestMethod]
+    public async Task Analyzer_Class_KeywordsInOrder_NoDiagnostics()
+    {
+        string test = @"
+        public class MyClass
+        {
+            // Fields
+            public const int myPublicConstantField = 0;
+            public static readonly int myPublicStaticReadonlyField;
+            public static int myPublicStaticField;
+            public readonly int myPublicReadonlyField = 1;
+            public int myPublicField;
+
+            // Properties
+            public static int MyPublicStaticProperty { get; set; }
+            public int MyPublicProperty { get; set; }
+
+            // Delegates
+            public delegate void MyPublicDelegate();
+
+            // Events and event fields
+            public static event MyPublicDelegate MyPublicStaticEvent { add { } remove { } }
+            public static event MyPublicDelegate MyPublicStaticEventField;
+            public event MyPublicDelegate MyPublicEvent { add { } remove { } }
+            public event MyPublicDelegate MyPublicEventField;
+
+            // Methods
+            public static void MyPublicStaticMethod() { }
+            public void MyPublicMethod() { }
+        }";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [TestMethod]
     public async Task Analyzer_Class_ConstructorBeforeIndexer_SingleDiagnostic()
     {
         string test = @"


### PR DESCRIPTION
- Added support for sorting members with the `readonly` keyword and nested types.
- Added more details to the exception that is thrown while trying to sort by name to make it easier to debug in the future.
- Fixed a bug in the logic used to maintain whitespace when reordering that was causing comments to get swapped.