### PR TITLE
Download LFS items at checkout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          lfs: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          lfs: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
This change fixes a packaging error related to `actions/checkout` not downloading LFS items at checkout.