### PR TITLE
Use .NET 8

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x
+        dotnet-version: 8.x
 
     - name: Install .NET tools
       shell: pwsh

--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: codecov
-          directory: __test-results
+          directory: __artifacts/test-results
           fail_ci_if_error: true
           verbose: true
 
@@ -63,10 +63,10 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: output_${{ inputs.platform }}
-          path: __output
+          path: __artifacts/bin
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v3
         with:
           name: packages_${{ inputs.platform }}
-          path: __packages
+          path: __artifacts/package

--- a/.github/workflows/workflow_release.yml
+++ b/.github/workflows/workflow_release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: packages_ubuntu
-          path: __packages
+          path: __artifacts/package
 
       - name: Push ${{ inputs.package-version }} to NuGet.org
-        run: nuget push __packages/NuGet/Release/Treasure.Analyzers.*.nupkg -ApiKey ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json
+        run: nuget push __artifacts/package/release/Treasure.Analyzers.*.nupkg -ApiKey ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,12 +4,10 @@
     <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
     <EngRootPath>$(RepoRootPath)eng/</EngRootPath>
     <SourceRootPath>$(RepoRootPath)src</SourceRootPath>
-    <CentralBuildOutputPath>$(RepoRootPath)</CentralBuildOutputPath>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(RepoRootPath)__artifacts</ArtifactsPath>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\eng\Defaults.props" />
-
-  <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" />
 
 </Project>

--- a/eng/DotNetAnalyzers.props
+++ b/eng/DotNetAnalyzers.props
@@ -7,7 +7,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisLevel>7.0</AnalysisLevel>
+    <AnalysisLevel>8.0</AnalysisLevel>
   </PropertyGroup>
 
 </Project>

--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -10,7 +10,7 @@
     <!-- Sets the C# language version:
       https://docs.microsoft.com/dotnet/csharp/language-reference/configure-language-version#c-language-version-reference
     -->
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>latest</LangVersion>
 
     <!-- Enable implicit usings:
       https://docs.microsoft.com/dotnet/core/project-sdk/overview#implicit-using-directives
@@ -52,6 +52,14 @@
   <PropertyGroup>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Configure test and code coverage output. -->
+    <BaseTestResultsOutputPath>$(ArtifactsPath)/test-results/</BaseTestResultsOutputPath>
+    <BaseProjectTestResultsOutputPath>$(BaseTestResultsOutputPath)$(MSBuildProjectName)/</BaseProjectTestResultsOutputPath>
+    <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
+    <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
   </PropertyGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "8.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
-  },
-  "msbuild-sdks": {
-    "Treasure.Build.CentralBuildOutput" : "3.0.0"
   }
 }

--- a/src/MemberOrder/MemberOrder.CodeFixes/MemberOrderCodeFixProvider.cs
+++ b/src/MemberOrder/MemberOrder.CodeFixes/MemberOrderCodeFixProvider.cs
@@ -72,12 +72,14 @@ public class MemberOrderCodeFixProvider : CodeFixProvider
     private static async Task<Document> ReorderMembersAsync(Document document, TypeDeclarationSyntax declaration, CancellationToken cancellationToken)
     {
         SyntaxList<MemberDeclarationSyntax> members = declaration.Members;
-        List<MemberDeclarationSyntax> sortedMembers = members
+        List<MemberDeclarationSyntax> sortedMembers =
+        [
+            .. members
             .OrderBy(MemberOrderAnalyzer.GetMemberCategoryOrder)
             .ThenBy(MemberOrderAnalyzer.GetAccessibilityModifierOrder)
             .ThenBy(MemberOrderAnalyzer.GetSpecialKeywordOrder)
             .ThenBy(MemberOrderAnalyzer.GetMemberName)
-            .ToList();
+        ];
         TryKeepWhiteSpace(ref members, sortedMembers);
         TypeDeclarationSyntax newDeclaration = declaration.WithMembers(SyntaxFactory.List(sortedMembers));
 

--- a/src/MemberOrder/MemberOrder/MemberOrderAnalyzer.cs
+++ b/src/MemberOrder/MemberOrder/MemberOrderAnalyzer.cs
@@ -231,12 +231,14 @@ public class MemberOrderAnalyzer : DiagnosticAnalyzer
         TypeDeclarationSyntax typeDeclaration = (TypeDeclarationSyntax)context.Node;
         Location declarationLocation = typeDeclaration.GetLocation();
         SyntaxList<MemberDeclarationSyntax> members = typeDeclaration.Members;
-        List<MemberDeclarationSyntax> sortedMembers = members
+        List<MemberDeclarationSyntax> sortedMembers =
+        [
+            .. members
             .OrderBy(GetMemberCategoryOrder)
             .ThenBy(GetAccessibilityModifierOrder)
             .ThenBy(GetSpecialKeywordOrder)
             .ThenBy(GetMemberName)
-            .ToList();
+        ];
 
         for (int i = 0; i < members.Count; i++)
         {

--- a/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrder.CodeFixes.Tests.csproj
+++ b/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrder.CodeFixes.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrder.Tests.csproj
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrder.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests.cs
@@ -107,7 +107,7 @@ public sealed class MemberOrderUnitTests
 
     private sealed class MockAnalysisContext : AnalysisContext
     {
-        public List<SyntaxKind> RegisteredSyntaxKinds { get; } = new();
+        public List<SyntaxKind> RegisteredSyntaxKinds { get; } = [];
 
         public override void ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags analysisMode) { }
 

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_Class.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_Class.cs
@@ -187,12 +187,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -210,12 +210,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -233,12 +233,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -256,12 +256,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -279,12 +279,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -303,12 +303,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -327,12 +327,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -387,12 +387,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -410,12 +410,12 @@ public class MemberOrderUnitTests_Class
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -485,12 +485,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -524,12 +524,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -565,12 +565,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -604,12 +604,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -647,12 +647,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -688,12 +688,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -729,12 +729,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -772,12 +772,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -813,12 +813,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -854,12 +854,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -895,12 +895,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -934,12 +934,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -997,12 +997,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1056,12 +1056,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1097,12 +1097,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1136,12 +1136,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1193,12 +1193,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1234,12 +1234,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1273,12 +1273,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1330,12 +1330,12 @@ public class MemberOrderUnitTests_Class
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyClass"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_Interface.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_Interface.cs
@@ -142,12 +142,12 @@ public class MemberOrderUnitTests_Interface
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -165,12 +165,12 @@ public class MemberOrderUnitTests_Interface
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -188,12 +188,12 @@ public class MemberOrderUnitTests_Interface
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -212,12 +212,12 @@ public class MemberOrderUnitTests_Interface
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -236,12 +236,12 @@ public class MemberOrderUnitTests_Interface
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -298,12 +298,12 @@ public class MemberOrderUnitTests_Interface
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -373,12 +373,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -412,12 +412,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -455,12 +455,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -496,12 +496,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -537,12 +537,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -580,12 +580,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -621,12 +621,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -662,12 +662,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -703,12 +703,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -742,12 +742,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -783,12 +783,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -842,12 +842,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -883,12 +883,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -922,12 +922,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -979,12 +979,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1020,12 +1020,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1059,12 +1059,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1116,12 +1116,12 @@ public class MemberOrderUnitTests_Interface
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyInterface"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_Record.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_Record.cs
@@ -187,12 +187,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -210,12 +210,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -233,12 +233,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -256,12 +256,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -279,12 +279,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -303,12 +303,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -327,12 +327,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -387,12 +387,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -410,12 +410,12 @@ public class MemberOrderUnitTests_Record
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -485,12 +485,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -524,12 +524,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -565,12 +565,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -604,12 +604,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -647,12 +647,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -688,12 +688,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -729,12 +729,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -772,12 +772,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -813,12 +813,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -854,12 +854,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -895,12 +895,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -934,12 +934,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -997,12 +997,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1056,12 +1056,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1097,12 +1097,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1136,12 +1136,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1193,12 +1193,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1234,12 +1234,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1273,12 +1273,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1330,12 +1330,12 @@ public class MemberOrderUnitTests_Record
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecord"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_RecordStruct.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_RecordStruct.cs
@@ -118,12 +118,12 @@ public class MemberOrderUnitTests_RecordStruct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -141,12 +141,12 @@ public class MemberOrderUnitTests_RecordStruct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -164,12 +164,12 @@ public class MemberOrderUnitTests_RecordStruct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -187,12 +187,12 @@ public class MemberOrderUnitTests_RecordStruct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -211,12 +211,12 @@ public class MemberOrderUnitTests_RecordStruct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -235,12 +235,12 @@ public class MemberOrderUnitTests_RecordStruct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -298,12 +298,12 @@ public class MemberOrderUnitTests_RecordStruct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -373,12 +373,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -412,12 +412,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -453,12 +453,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -492,12 +492,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -535,12 +535,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -576,12 +576,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -617,12 +617,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -660,12 +660,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -701,12 +701,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -742,12 +742,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -783,12 +783,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -822,12 +822,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -891,12 +891,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -952,12 +952,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -993,12 +993,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1032,12 +1032,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1089,12 +1089,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1130,12 +1130,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1169,12 +1169,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1226,12 +1226,12 @@ public class MemberOrderUnitTests_RecordStruct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyRecordStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);

--- a/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_Struct.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/MemberOrderUnitTests_Struct.cs
@@ -184,12 +184,12 @@ public class MemberOrderUnitTests_Struct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -207,12 +207,12 @@ public class MemberOrderUnitTests_Struct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -230,12 +230,12 @@ public class MemberOrderUnitTests_Struct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -253,12 +253,12 @@ public class MemberOrderUnitTests_Struct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -277,12 +277,12 @@ public class MemberOrderUnitTests_Struct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -301,12 +301,12 @@ public class MemberOrderUnitTests_Struct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -364,12 +364,12 @@ public class MemberOrderUnitTests_Struct
         }
         """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -439,12 +439,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -478,12 +478,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -519,12 +519,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -558,12 +558,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -601,12 +601,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -642,12 +642,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -683,12 +683,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -726,12 +726,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -767,12 +767,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -808,12 +808,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -849,12 +849,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -888,12 +888,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -957,12 +957,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1018,12 +1018,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1059,12 +1059,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1098,12 +1098,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1155,12 +1155,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1196,12 +1196,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1235,12 +1235,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);
@@ -1292,12 +1292,12 @@ public class MemberOrderUnitTests_Struct
             }
             """;
 
-        DiagnosticResult[] expectedDiagnosticResults = new[]
-        {
+        DiagnosticResult[] expectedDiagnosticResults =
+        [
             VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
                 .WithLocation(string.Empty, 1, 1)
                 .WithArguments("MyStruct"),
-        };
+        ];
 
         // Act and assert
         await VerifyCS.VerifyAnalyzerAsync(sourceText, expectedDiagnosticResults);

--- a/tests/MemberOrder/MemberOrder.Tests/TestUtils/TestData.cs
+++ b/tests/MemberOrder/MemberOrder.Tests/TestUtils/TestData.cs
@@ -2,47 +2,47 @@
 
 internal static class TestData
 {
-    public static IEnumerable<object[]> ClassAccessModifiersInOrder => new[]
-    {
-        new object[] { "public", "internal" },
-        new object[] { "internal", "protected internal" },
-        new object[] { "protected internal", "private protected" },
-        new object[] { "private protected", "protected" },
-        new object[] { "protected", "private" },
-    };
+    public static IEnumerable<object[]> ClassAccessModifiersInOrder =>
+    [
+        ["public", "internal"],
+        ["internal", "protected internal"],
+        ["protected internal", "private protected"],
+        ["private protected", "protected"],
+        ["protected", "private"],
+    ];
 
-    public static IEnumerable<object[]> ClassAccessModifiersNotInOrder => new[]
-    {
-        new object[] { "internal", "public" },
-        new object[] { "protected internal", "internal" },
-        new object[] { "private protected", "protected internal" },
-        new object[] { "protected", "private protected" },
-        new object[] { "private", "protected" },
-    };
+    public static IEnumerable<object[]> ClassAccessModifiersNotInOrder =>
+    [
+        ["internal", "public"],
+        ["protected internal", "internal"],
+        ["private protected", "protected internal"],
+        ["protected", "private protected"],
+        ["private", "protected"],
+    ];
 
-    public static IEnumerable<object[]> InterfaceAccessModifiersInOrder => new[]
-    {
-        new object[] { "public", "internal" },
-        new object[] { "internal", "protected internal" },
-        new object[] { "protected internal", "private protected" },
-    };
+    public static IEnumerable<object[]> InterfaceAccessModifiersInOrder =>
+    [
+        ["public", "internal"],
+        ["internal", "protected internal"],
+        ["protected internal", "private protected"],
+    ];
 
-    public static IEnumerable<object[]> InterfaceAccessModifiersNotInOrder => new[]
-    {
-        new object[] { "internal", "public" },
-        new object[] { "protected internal", "internal" },
-        new object[] { "private protected", "protected internal" },
-    };
+    public static IEnumerable<object[]> InterfaceAccessModifiersNotInOrder =>
+    [
+        ["internal", "public"],
+        ["protected internal", "internal"],
+        ["private protected", "protected internal"],
+    ];
 
-    public static IEnumerable<object[]> StructAccessModifiersInOrder => new[]
-    {
-        new object[] { "public", "internal" },
-        new object[] { "internal", "private" },
-    };
+    public static IEnumerable<object[]> StructAccessModifiersInOrder =>
+    [
+        ["public", "internal"],
+        ["internal", "private"],
+    ];
 
-    public static IEnumerable<object[]> StructAccessModifiersNotInOrder => new[]
-    {
-        new object[] { "internal", "public" },
-        new object[] { "private", "internal" },
-    };
+    public static IEnumerable<object[]> StructAccessModifiersNotInOrder =>
+    [
+        ["internal", "public"],
+        ["private", "internal"],
+    ];
 }

--- a/tests/TestVerifiers.Library/CSharpCodeFixVerifier`2.cs
+++ b/tests/TestVerifiers.Library/CSharpCodeFixVerifier`2.cs
@@ -46,7 +46,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 
     /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
     public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
-        => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+        => await VerifyCodeFixAsync(source, [expected], fixedSource);
 
     /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
     public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)

--- a/tests/TestVerifiers.Library/CSharpCodeRefactoringVerifier`1.cs
+++ b/tests/TestVerifiers.Library/CSharpCodeRefactoringVerifier`1.cs
@@ -20,7 +20,7 @@ public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
     /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
     public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
     {
-        await VerifyRefactoringAsync(source, new[] { expected }, fixedSource);
+        await VerifyRefactoringAsync(source, [expected], fixedSource);
     }
 
     /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>

--- a/tests/TestVerifiers.Library/CSharpVerifierHelper.cs
+++ b/tests/TestVerifiers.Library/CSharpVerifierHelper.cs
@@ -19,7 +19,7 @@ internal static class CSharpVerifierHelper
 
     private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
     {
-        string[] args = { "/warnaserror:nullable" };
+        string[] args = ["/warnaserror:nullable"];
         CSharpCommandLineArguments commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
         ImmutableDictionary<string, ReportDiagnostic> nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
 


### PR DESCRIPTION
This change upgrades the repo to use the .NET 8 SDK and .NET 8 runtime for test projects.