### PR TITLE
Upgrade Microsoft.VSSDK.BuildTools

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                  Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                     Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces"          Version="4.8.0" />
-    <PackageVersion Include="Microsoft.VSSDK.BuildTools"                        Version="17.7.2196" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools"                        Version="17.8.2365" />
     <PackageVersion Include="Treasure.Utils.Argument"                           Version="1.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This change upgrades `Microsoft.VSSDK.BuildTools` to `17.8.2365`.