### PR TITLE
Remove net7.0 usage

### DIFF
--- a/tests/TestVerifiers.Library/TestVerifiers.Library.csproj
+++ b/tests/TestVerifiers.Library/TestVerifiers.Library.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>


### PR DESCRIPTION
After updating to .NET 8 in #18, we missed one use of `net7.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the underlying framework version to enhance compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->