### PR TITLE
Update test packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,9 +41,9 @@
     <PackageVersion Include="MSTest.TestAdapter"                                Version="3.4.3" />
     <PackageVersion Include="MSTest.TestFramework"                              Version="3.4.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis"                            Version="4.10.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing"    Version="1.1.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing"     Version="1.1.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing"    Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing"     Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change updates the `Microsoft.CodeAnalysis*` packages to the latest version since Dependabot can't seem to handle that anymore. These package updates actually include some breaking changes, but those breaking changes were addressed beforehand in #46 so that this update could be done cleanly.