### PR TITLE
Configure .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,13 @@ updates:
       - "Nerdbank.GitVersioning"
       - "nbgv"
 
+- package-ecosystem: 'dotnet-sdk'
+  directory: "/"
+  schedule:
+    interval: 'weekly'
+    day: 'tuesday'
+    time: '22:00'
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.200",
     "allowPrerelease": false,
-    "rollForward": "latestFeature"
+    "rollForward": "latestPatch"
   }
 }

--- a/src/MemberOrder/MemberOrder.CodeFixes/SyntaxExtensions.cs
+++ b/src/MemberOrder/MemberOrder.CodeFixes/SyntaxExtensions.cs
@@ -23,8 +23,8 @@ internal static class SyntaxExtensions
 
     public static MemberDeclarationSyntax WithLeadingWhitespaceFrom(this MemberDeclarationSyntax targetMember, MemberDeclarationSyntax whitespaceSourceMember)
     {
-        IEnumerable<SyntaxTrivia> newLeadingWhitespace = whitespaceSourceMember.GetLeadingTrivia().GetLeadingWhitespace().ToArray();
-        IEnumerable<SyntaxTrivia> leadingNonWhitespace = targetMember.GetLeadingTrivia().WithoutLeadingWhitespace().ToArray();
+        IEnumerable<SyntaxTrivia> newLeadingWhitespace = [.. whitespaceSourceMember.GetLeadingTrivia().GetLeadingWhitespace()];
+        IEnumerable<SyntaxTrivia> leadingNonWhitespace = [.. targetMember.GetLeadingTrivia().WithoutLeadingWhitespace()];
         return targetMember.WithLeadingTrivia(newLeadingWhitespace.Concat(leadingNonWhitespace));
     }
 


### PR DESCRIPTION
- Updated to 9.0.200 .NET SDK
- Enabled automated .NET SDK updates from Dependabot
- Fixed 9.0.200 related analyzer updates
- Changed `rollForward` to `latestPatch` to prevent SDK breaking changes until upgrade