### PR TITLE
Fix nested type handling in MemberOrderCodeFixProvider

### DIFF
--- a/src/MemberOrder/MemberOrder.CodeFixes/MemberOrderCodeFixProvider.cs
+++ b/src/MemberOrder/MemberOrder.CodeFixes/MemberOrderCodeFixProvider.cs
@@ -57,7 +57,7 @@ public class MemberOrderCodeFixProvider : CodeFixProvider
                 .FindToken(diagnosticSpan.Start)
                 .Parent?.AncestorsAndSelf()
                 .OfType<TypeDeclarationSyntax>()
-                .Single()
+                .First()
                 ?? throw new InvalidOperationException("The type declaration was null.");
 
             context.RegisterCodeFix(

--- a/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrderCodeFixProviderTests_NestedTypes.cs
+++ b/tests/MemberOrder/MemberOrder.CodeFixes.Tests/MemberOrderCodeFixProviderTests_NestedTypes.cs
@@ -1,0 +1,455 @@
+﻿namespace Treasure.Analyzers.MemberOrder.CodeFixes.Tests;
+
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using VerifyCS = TestVerifiers.CSharpCodeFixVerifier<
+    MemberOrderAnalyzer,
+    MemberOrderCodeFixProvider>;
+
+[TestClass]
+public class MemberOrderCodeFixProviderTests_NestedTypes
+{
+    [TestMethod]
+    public async Task NestedClass_InnerClassMembersOutOfOrder_InnerClassReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public class InnerClass
+            {
+                private void InnerMethod() { }
+                private int innerField;
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public class InnerClass
+            {
+                private int innerField;
+                private void InnerMethod() { }
+            }
+        }
+        """;
+
+        DiagnosticResult expectedDiagnosticResults = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+            .WithLocation(string.Empty, 5, 5)
+            .WithArguments("InnerClass");
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task NestedClass_OuterClassMembersOutOfOrder_OuterClassReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+            public int outerField;
+
+            public class InnerClass
+            {
+                private int innerField;
+                private void InnerMethod() { }
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public class OuterClass
+        {
+            public int outerField;
+            public void OuterMethod() { }
+
+            public class InnerClass
+            {
+                private int innerField;
+                private void InnerMethod() { }
+            }
+        }
+        """;
+
+        DiagnosticResult expectedDiagnosticResults = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+            .WithLocation(string.Empty, 1, 1)
+            .WithArguments("OuterClass");
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task NestedClass_BothOuterAndInnerMembersOutOfOrder_BothReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+            public int outerField;
+
+            public class InnerClass
+            {
+                private void InnerMethod() { }
+                private int innerField;
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public class OuterClass
+        {
+            public int outerField;
+            public void OuterMethod() { }
+
+            public class InnerClass
+            {
+                private int innerField;
+                private void InnerMethod() { }
+            }
+        }
+        """;
+
+        DiagnosticResult[] expectedDiagnosticResults = [
+            VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+                .WithLocation(string.Empty, 1, 1)
+                .WithArguments("OuterClass"),
+            VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+                .WithLocation(string.Empty, 6, 5)
+                .WithArguments("InnerClass")
+        ];
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task NestedStruct_InnerStructMembersOutOfOrder_InnerStructReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public struct InnerStruct
+            {
+                private void InnerMethod() { }
+                private int innerField;
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public struct InnerStruct
+            {
+                private int innerField;
+                private void InnerMethod() { }
+            }
+        }
+        """;
+
+        DiagnosticResult expectedDiagnosticResults = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+            .WithLocation(string.Empty, 5, 5)
+            .WithArguments("InnerStruct");
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task NestedRecord_InnerRecordMembersOutOfOrder_InnerRecordReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public record InnerRecord
+            {
+                private void InnerMethod() { }
+                private int innerField;
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public record InnerRecord
+            {
+                private int innerField;
+                private void InnerMethod() { }
+            }
+        }
+        """;
+
+        DiagnosticResult expectedDiagnosticResults = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+            .WithLocation(string.Empty, 5, 5)
+            .WithArguments("InnerRecord");
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task NestedInterface_InnerInterfaceMembersOutOfOrder_InnerInterfaceReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public interface IInnerInterface
+            {
+                void InnerMethodB();
+                int InnerProperty { get; set; }
+                void InnerMethodA();
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public interface IInnerInterface
+            {
+                int InnerProperty { get; set; }
+                void InnerMethodA();
+                void InnerMethodB();
+            }
+        }
+        """;
+
+        DiagnosticResult expectedDiagnosticResults = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+            .WithLocation(string.Empty, 5, 5)
+            .WithArguments("IInnerInterface");
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task MultipleNestedLevels_DeepestLevelOutOfOrder_DeepestLevelReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public class MiddleClass
+            {
+                public void MiddleMethod() { }
+
+                public class InnerClass
+                {
+                    private void InnerMethod() { }
+                    private int innerField;
+                }
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+
+            public class MiddleClass
+            {
+                public void MiddleMethod() { }
+
+                public class InnerClass
+                {
+                    private int innerField;
+                    private void InnerMethod() { }
+                }
+            }
+        }
+        """;
+
+        DiagnosticResult expectedDiagnosticResults = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+            .WithLocation(string.Empty, 9, 9)
+            .WithArguments("InnerClass");
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task MultipleNestedLevels_AllLevelsOutOfOrder_AllLevelsReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public class OuterClass
+        {
+            public void OuterMethod() { }
+            public int outerField;
+
+            public class MiddleClass
+            {
+                public void MiddleMethod() { }
+                public int middleField;
+
+                public class InnerClass
+                {
+                    private void InnerMethod() { }
+                    private int innerField;
+                }
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public class OuterClass
+        {
+            public int outerField;
+            public void OuterMethod() { }
+
+            public class MiddleClass
+            {
+                public int middleField;
+                public void MiddleMethod() { }
+
+                public class InnerClass
+                {
+                    private int innerField;
+                    private void InnerMethod() { }
+                }
+            }
+        }
+        """;
+
+        DiagnosticResult[] expectedDiagnosticResults = [
+            VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+                .WithLocation(string.Empty, 1, 1)
+                .WithArguments("OuterClass"),
+            VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+                .WithLocation(string.Empty, 6, 5)
+                .WithArguments("MiddleClass"),
+            VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+                .WithLocation(string.Empty, 11, 9)
+                .WithArguments("InnerClass")
+        ];
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task StructWithNestedClass_InnerClassOutOfOrder_InnerClassReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public struct OuterStruct
+        {
+            public void OuterMethod() { }
+
+            public class InnerClass
+            {
+                private void InnerMethod() { }
+                private int innerField;
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public struct OuterStruct
+        {
+            public void OuterMethod() { }
+
+            public class InnerClass
+            {
+                private int innerField;
+                private void InnerMethod() { }
+            }
+        }
+        """;
+
+        DiagnosticResult expectedDiagnosticResults = VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+            .WithLocation(string.Empty, 5, 5)
+            .WithArguments("InnerClass");
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText);
+    }
+
+    [TestMethod]
+    public async Task RecordWithNestedTypes_MixedNestedTypesOutOfOrder_NestedTypesReordered()
+    {
+        // Arrange
+        const string sourceText = """
+        public record OuterRecord
+        {
+            public void OuterMethod() { }
+
+            public class InnerClass
+            {
+                private void InnerMethod() { }
+                private int innerField;
+            }
+
+            public struct InnerStruct
+            {
+                private void StructMethod() { }
+                private int structField;
+            }
+        }
+        """;
+
+        const string expectedFixedSourceText = """
+        public record OuterRecord
+        {
+            public void OuterMethod() { }
+
+            public struct InnerStruct
+            {
+                private int structField;
+                private void StructMethod() { }
+            }
+
+            public class InnerClass
+            {
+                private int innerField;
+                private void InnerMethod() { }
+            }
+        }
+        """;
+
+        DiagnosticResult[] expectedDiagnosticResults = [
+            VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+                .WithLocation(string.Empty, 1, 1)
+                .WithArguments("OuterRecord"),
+            VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+                .WithLocation(string.Empty, 5, 5)
+                .WithArguments("InnerClass"),
+            VerifyCS.Diagnostic(MemberOrderAnalyzer.DiagnosticId)
+                .WithLocation(string.Empty, 11, 5)
+                .WithArguments("InnerStruct")
+        ];
+
+        // Act and assert
+        await VerifyCS.VerifyCodeFixAsync(sourceText, expectedDiagnosticResults, expectedFixedSourceText, 2);
+    }
+}

--- a/tests/TestVerifiers.Library/CSharpCodeFixVerifier`2.cs
+++ b/tests/TestVerifiers.Library/CSharpCodeFixVerifier`2.cs
@@ -60,6 +60,27 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         await test.RunAsync(CancellationToken.None);
     }
 
+    /// <summary>
+    /// Verifies that the analyzer will produce the specified diagnostics and that the code fix will fix the code.
+    /// </summary>
+    /// <param name="source">The source text to test</param>
+    /// <param name="expected">The expected diagnostic results</param>
+    /// <param name="fixedSource">The expected fixed source text</param>
+    /// <param name="numberOfFixAllIterations">The number of fix-all iterations expected</param>
+    /// <returns>A task representing the asynchronous operation</returns>
+    public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource, int numberOfFixAllIterations)
+    {
+        Test test = new()
+        {
+            TestCode = source,
+            FixedCode = fixedSource,
+            NumberOfFixAllIterations = numberOfFixAllIterations,
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
+    }
+
     internal sealed class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
     {
         public Test()


### PR DESCRIPTION
Change Single() to First() when finding type declarations to handle nested types correctly, and add comprehensive tests for nested class scenarios including inner class reordering, outer class reordering, and mixed reordering cases.

Fixes VS error: Sequence contains more than one element #21