### PR TITLE
Update package icon and preserve original version

### DIFF
--- a/src/MemberOrder/MemberOrder.Package/icon-original.png
+++ b/src/MemberOrder/MemberOrder.Package/icon-original.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdd8ca4b9eb76473c9369d7017982dc0c3cb1681d9d07463d0310bfc18d396da
+size 190934

--- a/src/MemberOrder/MemberOrder.Package/icon.png
+++ b/src/MemberOrder/MemberOrder.Package/icon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdd8ca4b9eb76473c9369d7017982dc0c3cb1681d9d07463d0310bfc18d396da
-size 190934
+oid sha256:25efaa35071849c390c47d97f3466dc97b3fd97e4c7b2e179980f891d7c51d7e
+size 21379


### PR DESCRIPTION
- Replace icon.png with optimized version (reduced from 190KB to 21KB)
- Add icon-original.png to preserve the original high-resolution version