### PR TITLE
Enable Git LFS support and remove NoPackageAnalysis flag

### DIFF
--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          lfs: true
+
+      - name: Pull LFS objects
+        run: git lfs pull
 
       - name: Install tools
         uses: ./.github/actions/install-tools

--- a/src/MemberOrder/MemberOrder.Package/MemberOrder.Package.csproj
+++ b/src/MemberOrder/MemberOrder.Package/MemberOrder.Package.csproj
@@ -14,7 +14,6 @@
     <Description>An analyzer and code fixer used to keep members in a specific order.</Description>
     <PackageTags>Treasure, MemberOrder, analyzers</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <NoPackageAnalysis>true</NoPackageAnalysis>
 
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>


### PR DESCRIPTION
- Add LFS configuration to GitHub workflow for proper file handling
- Remove NoPackageAnalysis property to enable standard package validation