### PR TITLE
Upgrade NuGet packages and GitHub Actions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet sdk check:*)",
+      "Bash(dotnet list package:*)",
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)"
+    ]
+  }
+}

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,19 +9,9 @@ updates:
     timezone: 'America/Los_Angeles'
   open-pull-requests-limit: 10
   groups:
-    coverlet:
+    all-nuget:
       patterns:
-      - "coverlet*"
-    MSTest:
-      patterns:
-      - "MSTest.*"
-    Microsoft.CodeAnalysis:
-      patterns:
-      - "Microsoft.CodeAnalysis*"
-    gitversioning:
-      patterns:
-      - "Nerdbank.GitVersioning"
-      - "nbgv"
+      - "*"
 
 - package-ecosystem: 'dotnet-sdk'
   directory: "/"
@@ -39,3 +29,7 @@ updates:
     time: '17:00'
     timezone: 'America/Los_Angeles'
   open-pull-requests-limit: 10
+  groups:
+    all-actions:
+      patterns:
+      - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Find CI run to release
         id: find_run
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const runId = '${{ inputs.run_id }}';
@@ -61,7 +61,7 @@ jobs:
 
       - name: Validate CI run
         id: get_version
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const runId = '${{ steps.find_run.outputs.run_id }}';

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,16 +30,16 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                  Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                     Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces"          Version="5.3.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.SDK.Analyzers"              Version="17.7.98" />
-    <PackageVersion Include="Microsoft.VSSDK.BuildTools"                        Version="17.14.2120" />
+    <PackageVersion Include="Microsoft.VisualStudio.SDK.Analyzers"              Version="17.7.113" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools"                        Version="17.14.2142" />
   </ItemGroup>
 
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">
     <PackageVersion Include="coverlet.collector"                                Version="8.0.1" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="8.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="18.3.0" />
-    <PackageVersion Include="MSTest.TestAdapter"                                Version="4.1.0" />
-    <PackageVersion Include="MSTest.TestFramework"                              Version="4.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="18.4.0" />
+    <PackageVersion Include="MSTest.TestAdapter"                                Version="4.2.1" />
+    <PackageVersion Include="MSTest.TestFramework"                              Version="4.2.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis"                            Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing"    Version="1.1.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing"     Version="1.1.3" />


### PR DESCRIPTION
## Summary

- Upgrade 5 NuGet packages to latest stable versions (`Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, `MSTest.TestFramework`, `Microsoft.VisualStudio.SDK.Analyzers`, `Microsoft.VSSDK.BuildTools`)
- Upgrade `actions/setup-dotnet` from v3 to v5 and `actions/github-script` from v8 to v9
- Configure Dependabot to group all NuGet updates and all GitHub Actions updates into single PRs instead of separate groups
- Add Claude Code settings