### PR TITLE
chore: upgrade NuGet packages, tools, and GitHub Actions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.10.85",
+      "version": "3.10.91",
       "commands": [
         "nbgv"
       ]

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,14 +22,14 @@
     https://learn.microsoft.com/nuget/consume-packages/central-package-management#global-package-references
     -->
   <ItemGroup Label="Source Only Global Packages" Condition=" '$(SourceOnlyPackagesEnabled)' == 'true' ">
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub"               Version="10.0.300" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning"                    Version="3.10.85" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub"               Version="10.0.301" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning"                    Version="3.10.91" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                  Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                     Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces"          Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                  Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                     Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces"          Version="5.6.0" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK"                        Version="17.14.40265" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.Analyzers"              Version="17.7.113" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools"                        Version="18.5.40034" />
@@ -38,14 +38,13 @@
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">
     <PackageVersion Include="coverlet.collector"                                Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="10.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="18.7.0" />
-    <PackageVersion Include="MSTest.TestAdapter"                                Version="4.2.3" />
-    <PackageVersion Include="MSTest.TestFramework"                              Version="4.2.3" />
-    <PackageVersion Include="Microsoft.CodeAnalysis"                            Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing"    Version="1.1.3" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing"     Version="1.1.3" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.3" />
-    <PackageVersion Include="System.Formats.Asn1"                               Version="9.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="18.8.1" />
+    <PackageVersion Include="MSTest.TestAdapter"                                Version="4.3.2" />
+    <PackageVersion Include="MSTest.TestFramework"                              Version="4.3.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis"                            Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing"    Version="1.1.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing"     Version="1.1.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update dependencies to their latest versions.

## NuGet packages
- `Microsoft.CodeAnalysis`: 5.3.0 → 5.6.0
- `Microsoft.CodeAnalysis.Analyzers`: 5.3.0 → 5.6.0
- `Microsoft.CodeAnalysis.CSharp`: 5.3.0 → 5.6.0
- `Microsoft.CodeAnalysis.CSharp.Workspaces`: 5.3.0 → 5.6.0
- `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing`: 1.1.3 → 1.1.4
- `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing`: 1.1.3 → 1.1.4
- `Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing`: 1.1.3 → 1.1.4
- `Microsoft.NET.Test.Sdk`: 18.7.0 → 18.8.1
- `Microsoft.SourceLink.GitHub`: 10.0.300 → 10.0.301
- `MSTest.TestAdapter`: 4.2.3 → 4.3.2
- `MSTest.TestFramework`: 4.2.3 → 4.3.2
- `Nerdbank.GitVersioning`: 3.10.85 → 3.10.91

## Tools
- `nbgv`: 3.10.85 → 3.10.91

## GitHub Actions
- `actions/setup-dotnet`: v5 → v6

## Cleanup
Removed the now-redundant `System.Formats.Asn1` transitive pin. It was added during the .NET 9 upgrade to force out a vulnerable version; the dependency tree now resolves 9.0.6 on its own with no advisories.