### PR TITLE
chore: pin MessagePack to patch CVE-2026-48109

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.SDK"                        Version="17.14.40265" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.Analyzers"              Version="17.7.113" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools"                        Version="18.5.40034" />
+    <!-- Transitively pinned to patch CVE-2026-48109 (High). Pulled in by Microsoft.VisualStudio.SDK at 2.5.192. -->
+    <PackageVersion Include="MessagePack"                                       Version="2.5.302" />
   </ItemGroup>
 
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">


### PR DESCRIPTION
Pin `MessagePack` to **2.5.302** to address a High-severity advisory surfaced by `dotnet list package --vulnerable`.

## Background
- `MessagePack 2.5.192` is pulled in transitively by `Microsoft.VisualStudio.SDK` (17.14.40265) in the `MemberOrder.Vsix` project, flowing through `Composition`, `ServiceHub.Framework`, `StreamJsonRpc`, and `Editor`.
- The VS SDK is already at its latest version and still references 2.5.192, so upgrading the SDK does not resolve it.

## Advisory
- **CVE-2026-48109** (High, CVSS 8.2): out-of-bounds read in MessagePack's LZ4 decompression (`Lz4Block`/`Lz4BlockArray`) when deserializing untrusted compressed data. Fixed in the v2 line at 2.5.301.
- Several related Moderate advisories are also present in 2.5.192 and are cleared by the same bump.

## Fix
Central Package Management transitive pinning is already enabled, so a single transitive pin forces the patched version:

```xml
<PackageVersion Include="MessagePack" Version="2.5.302" />
```

Stays on the same major (v2) line the SDK expects. `dotnet list package --vulnerable` now reports no vulnerable packages for the Vsix project, and the solution builds cleanly (0 warnings).

## Note on exposure
The VSIX references the SDK with `ExcludeAssets="runtime"`, so MessagePack is not shipped in the `.vsix` (Visual Studio provides it at runtime). Real-world risk is low; this primarily clears the scan finding and keeps the dependency on a patched version.